### PR TITLE
Test plan name param

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ optional arguments:
                         template for TestRail cases to make id string
   --env-description ENV_DESCRIPTION
                         env deploy type description (for TestRun name)
-  --iso-id ISO_ID       id of build Fuel iso
+  --testrail-plan-name TESTRAIL_PLANE_NAME
+                        name of test plan to be displayed in testrail
+  --iso-id ISO_ID       id of build Fuel iso (DEPRECATED)
   --test-results-link TEST_RESULTS_LINK
                         link to test job results
   --testrail-url TESTRAIL_URL

--- a/bin/report
+++ b/bin/report
@@ -30,7 +30,8 @@ def main():
         'XUNIT_REPORT': 'report.xml',
         'XUNIT_NAME_TEMPLATE': '{id}',
         'TESTRAIL_NAME_TEMPLATE': '{custom_report_label}',
-        'ISO_ID': '000',
+        'ISO_ID': '',
+        'TESTRAIL_PLAN_NAME': '',
         'ENV_DESCRIPTION': '',
         'TEST_RESULTS_LINK': '',
     }
@@ -55,10 +56,15 @@ def main():
                         type=str,
                         default=defaults['ENV_DESCRIPTION'],
                         help='env deploy type description (for TestRun name)')
+
     parser.add_argument('--iso-id',
-                        type=int,
+                        type=str,
                         default=defaults['ISO_ID'],
                         help='id of build Fuel iso')
+    parser.add_argument('--testrail-plan-name',
+                        type=str,
+                        default=defaults['TESTRAIL_PLAN_NAME'],
+                        help='name of test plan to be displayed in testrail')
     parser.add_argument('--test-results-link',
                         type=str,
                         default=defaults['TEST_RESULTS_LINK'],
@@ -117,6 +123,7 @@ def main():
                              password=args.testrail_password,
                              milestone=args.testrail_milestone,
                              project=args.testrail_project,
+                             plan_name=args.testrail_plan_name,
                              tests_suite=suite)
     reporter.execute()
 

--- a/bin/report
+++ b/bin/report
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import sys
+import warnings
 
 from testrail_reporter import CaseMapper
 from testrail_reporter import Reporter
@@ -57,14 +58,16 @@ def main():
                         default=defaults['ENV_DESCRIPTION'],
                         help='env deploy type description (for TestRun name)')
 
-    parser.add_argument('--iso-id',
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--iso-id',
                         type=str,
                         default=defaults['ISO_ID'],
                         help='id of build Fuel iso')
-    parser.add_argument('--testrail-plan-name',
+    group.add_argument('--testrail-plan-name',
                         type=str,
                         default=defaults['TESTRAIL_PLAN_NAME'],
                         help='name of test plan to be displayed in testrail')
+
     parser.add_argument('--test-results-link',
                         type=str,
                         default=defaults['TEST_RESULTS_LINK'],
@@ -102,6 +105,14 @@ def main():
 
     args = parser.parse_args()
 
+    if not args.testrail_plan_name:
+        args.testrail_plan_name = ('{0.testrail_milestone} iso '
+                                   '#{0.iso_id}').format(args)
+
+        msg = ("--iso-id parameter is DEPRECATED. "
+               "It is recommended to use --testrail-plan-name parameter.")
+        warnings.warn(msg, DeprecationWarning)
+
     logger_dict = dict(stream=sys.stderr)
     if args.verbose:
         logger_dict['level'] = logging.DEBUG
@@ -113,7 +124,6 @@ def main():
         testrail_name_template=args.testrail_name_template)
 
     reporter = Reporter(xunit_report=args.xunit_report,
-                        iso_id=args.iso_id,
                         env_description=args.env_description,
                         test_results_link=args.test_results_link,
                         case_mapper=case_mapper)

--- a/bin/report
+++ b/bin/report
@@ -10,6 +10,9 @@ from testrail_reporter import CaseMapper
 from testrail_reporter import Reporter
 
 
+warnings.simplefilter('always', DeprecationWarning)
+
+
 def filename(string):
     if not os.path.exists(string):
         msg = "%r is not exists" % string
@@ -31,8 +34,8 @@ def main():
         'XUNIT_REPORT': 'report.xml',
         'XUNIT_NAME_TEMPLATE': '{id}',
         'TESTRAIL_NAME_TEMPLATE': '{custom_report_label}',
-        'ISO_ID': '',
-        'TESTRAIL_PLAN_NAME': '',
+        'ISO_ID': None,
+        'TESTRAIL_PLAN_NAME': None,
         'ENV_DESCRIPTION': '',
         'TEST_RESULTS_LINK': '',
     }
@@ -58,7 +61,7 @@ def main():
                         default=defaults['ENV_DESCRIPTION'],
                         help='env deploy type description (for TestRun name)')
 
-    group = parser.add_mutually_exclusive_group()
+    group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--iso-id',
                         type=str,
                         default=defaults['ISO_ID'],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     scripts=['bin/report'],
     url="https://github.com/gdyuldin/testrail_reporter",
     install_requires=[
-        'requests',
+        'requests>=2.4.2',
         'pytest-runner',
     ],
     setup_requires=['setuptools_scm'],

--- a/testrail_reporter/reporter.py
+++ b/testrail_reporter/reporter.py
@@ -37,7 +37,7 @@ class Reporter(object):
         super(Reporter, self).__init__(*args, **kwargs)
 
     def config_testrail(self, base_url, username, password, milestone, project,
-                        tests_suite, plan_name=None):
+                        tests_suite, plan_name):
         self._config['testrail'] = dict(base_url=base_url,
                                         username=username,
                                         password=password, )

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -26,7 +26,6 @@ def testrail_client(mocker):
 def reporter(testrail_client):
     reporter = Reporter(xunit_report='tests/xunit_files/report.xml',
                         env_description='vlan_ceph',
-                        iso_id=385,
                         test_results_link="http://test_job/",
                         case_mapper=None)
     reporter.config_testrail(base_url="https://testrail",
@@ -36,14 +35,6 @@ def reporter(testrail_client):
                              project="Test Project",
                              tests_suite="Test Suite")
     return reporter
-
-
-@pytest.mark.parametrize('milestone, iso, name',
-                         (('8.0', '123', '8.0 iso #123'), ))
-def test_plan_name(reporter, milestone, iso, name):
-    reporter.iso_id = iso
-    reporter.milestone_name = milestone
-    assert reporter.get_plan_name() == name
 
 
 def test_parse_report(reporter):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -33,7 +33,8 @@ def reporter(testrail_client):
                              password="password",
                              milestone="0.1",
                              project="Test Project",
-                             tests_suite="Test Suite")
+                             tests_suite="Test Suite",
+                             plan_name="Plan name")
     return reporter
 
 


### PR DESCRIPTION
** Added --test-plan-name parameter.**

Added --test-plan-name parameter so that we can manually set test plan
name without using --iso-id parameter. This way is considered to be more
common as we can use it to send reports for previous versions of MOS such
as MOS 8.0.

--iso-id parameter is considered to be DEPRECATED now.