### PR TITLE
Remove hardcoded pastebin service that doesn't exists

### DIFF
--- a/xunit2testrail/cmd.py
+++ b/xunit2testrail/cmd.py
@@ -48,7 +48,7 @@ def parse_args(args):
         'TESTRAIL_PLAN_NAME': None,
         'ENV_DESCRIPTION': '',
         'TEST_RESULTS_LINK': '',
-        'PASTE_BASE_URL': 'http://srv62-bud.infra.mirantis.net:5000/'
+        'PASTE_BASE_URL': None
     }
     defaults = {k: os.environ.get(k, v) for k, v in defaults.items()}
 
@@ -132,7 +132,8 @@ def parse_args(args):
         '--paste-url',
         type=str_cls,
         default=defaults['PASTE_BASE_URL'],
-        help='paste service to send test case logs and trace')
+        help=('pastebin service JSON API URL to send test case logs and trace,'
+              ' example: http://localhost:5000/'))
     parser.add_argument(
         '--testrail-run-update',
         dest='use_test_run_if_exists',

--- a/xunit2testrail/reporter.py
+++ b/xunit2testrail/reporter.py
@@ -164,7 +164,7 @@ class Reporter(object):
         template = self.env.get_template('testrail_comment.md')
         jenkins_url = self.get_jenkins_report_url(xunit_case)
         paste_url = None
-        if not xunit_case.success:
+        if not xunit_case.success and self.paste_url:
             try:
                 paste_url = self.save_to_paste(xunit_case)
             except Exception as e:


### PR DESCRIPTION
Remove the requests to a hardcoded service URL:

WARNING:xunit2testrail.reporter:HTTPConnectionPool(host='srv62-bud.infra.mirantis.net', port=5000): Max retries exceeded with url: /json/?method=pastes.newPaste (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f9fae2d4a10>: Failed to establish a new connection: [Errno 110] Connection timed out',))
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): srv62-bud.infra.mirantis.net

WARNING:xunit2testrail.reporter:HTTPConnectionPool(host='srv62-bud.infra.mirantis.net', port=5000): Max retries exceeded with url: /json/?method=pastes.newPaste (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f9fae2d4e50>: Failed to establish a new connection: [Errno 110] Connection timed out',))
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): srv62-bud.infra.mirantis.net

WARNING:xunit2testrail.reporter:HTTPConnectionPool(host='srv62-bud.infra.mirantis.net', port=5000): Max retries exceeded with url: /json/?method=pastes.newPaste (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f9fae2d4ed0>: Failed to establish a new connection: [Errno 110] Connection timed out',))
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): srv62-bud.infra.mirantis.net
