### PR TITLE
New argument that allow to send duplicates, and minor bugfixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     ],
     extras_require={'test': [
         'pytest-mock',
-        'pytest-catchlog',
         'requests-mock',
     ]},
 )

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -25,7 +25,8 @@ def test_help(capsys, mocker):
 
 def test_reporter_map_cases(mocker):
     mock_map_cases = mocker.patch('xunit2testrail.reporter.Reporter.map_cases')
-    testargs = ['report', 'tests/xunit_files/report.xml']
+    testargs = ['report', 'tests/xunit_files/report.xml',
+                '--testrail-plan-name', 'testplan']
     mocker.patch.object(sys, 'argv', testargs)
     cmd.main()
     assert 1 == mock_map_cases.call_count
@@ -34,7 +35,8 @@ def test_reporter_map_cases(mocker):
 def test_reporter_dry_run_table_header(mocker, capsys):
     """Check that dry run prints table header."""
     mocker.patch('xunit2testrail.reporter.Reporter.map_cases')
-    testargs = ['report', '--dry-run', 'tests/xunit_files/report.xml']
+    testargs = ['report', '--dry-run', 'tests/xunit_files/report.xml',
+                '--testrail-plan-name', 'testplan']
     mocker.patch.object(sys, 'argv', testargs)
     cmd.main()
     out, err = capsys.readouterr()
@@ -47,7 +49,8 @@ def test_dry_run_not_create_entities_in_testrail(mocker, method):
     """Check that dry run mode is not create anything on testrail."""
     mocker.patch('xunit2testrail.reporter.Reporter.map_cases')
     method_mock = mocker.patch('xunit2testrail.reporter.Reporter.' + method)
-    testargs = ['report', '--dry-run', 'tests/xunit_files/report.xml']
+    testargs = ['report', '--dry-run', 'tests/xunit_files/report.xml',
+                '--testrail-plan-name', 'testplan']
     mocker.patch.object(sys, 'argv', testargs)
     cmd.main()
     assert not method_mock.called

--- a/xunit2testrail/cmd.py
+++ b/xunit2testrail/cmd.py
@@ -129,6 +129,11 @@ def parse_args(args):
         default=False,
         help='send skipped cases to testrail')
     parser.add_argument(
+        '--send-duplicates',
+        action='store_true',
+        default=False,
+        help='send duplicated cases to testrail')
+    parser.add_argument(
         '--paste-url',
         type=str_cls,
         default=defaults['PASTE_BASE_URL'],
@@ -209,6 +214,7 @@ def main(args=None):
         plan_name=args.testrail_plan_name,
         tests_suite=suite,
         send_skipped=args.send_skipped,
+        send_duplicates=args.send_duplicates,
         use_test_run_if_exists=args.use_test_run_if_exists)
 
     xunit_suite, _ = reporter.get_xunit_test_suite()

--- a/xunit2testrail/reporter.py
+++ b/xunit2testrail/reporter.py
@@ -45,7 +45,7 @@ class Reporter(object):
 
     def config_testrail(self, base_url, username, password, milestone, project,
                         tests_suite, plan_name, send_skipped=False,
-                        use_test_run_if_exists=False):
+                        use_test_run_if_exists=False, send_duplicates=False):
         self._config['testrail'] = dict(base_url=base_url,
                                         username=username,
                                         password=password, )
@@ -56,6 +56,7 @@ class Reporter(object):
         self.plan_description = '{plan_name} tests'.format(
             plan_name=self.plan_name)
         self.send_skipped = send_skipped
+        self.send_duplicates = send_duplicates
         self.use_test_run_if_exists = use_test_run_if_exists
 
     @property
@@ -211,7 +212,7 @@ class Reporter(object):
 
     def map_cases(self, xunit_suite):
         cases = self.suite.cases()
-        return self.case_mapper.map(xunit_suite, cases)
+        return self.case_mapper.map(xunit_suite, cases, self.send_duplicates)
 
     def fill_case_results(self, mapping):
         filtered_cases = []


### PR DESCRIPTION
- Add new argument that allows sending results even if we have duplication in xunit file or testrail cases.
- Fixed exception for test cases with brackets, parenthesis, and commas in name.
Example: "[k8s.io] EmptyDir volumes should support (root,0777,tmpfs) [Conformance] [sig-storage]"
re.compile(r'[{}]'.format('')) => sre_constants.error: unexpected end of regular expression
- Fix for "pytest-catchlog plugin has been merged into the core, please remove it from your requirements"